### PR TITLE
✨ (ui-craft-playground) Add sidebar menu for exploring UI Craft components

### DIFF
--- a/playgrounds/ui-craft-playground/app/(navigation)/components/CraftListSidebar.tsx
+++ b/playgrounds/ui-craft-playground/app/(navigation)/components/CraftListSidebar.tsx
@@ -11,9 +11,11 @@ import {
   SidebarTrigger,
 } from '@/shadcn-components/ui/sidebar';
 import Link from 'next/link';
+import { useMemo } from 'react';
 import { craftMetaMap } from '../data/craftMeta';
 
 export function CraftListSidebar() {
+  const craftEntries = useMemo(() => Array.from(craftMetaMap.entries()), []);
   return (
     <Sidebar>
       <SidebarContent>
@@ -21,7 +23,7 @@ export function CraftListSidebar() {
           <SidebarGroupLabel>ui-crafts</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {Array.from(craftMetaMap.entries()).map(([id, craft]) => (
+              {craftEntries.map(([id, craft]) => (
                 <SidebarMenuItem key={id}>
                   <SidebarMenuButton asChild>
                     <Link href={`/craft/${id}`}>

--- a/playgrounds/ui-craft-playground/app/(navigation)/components/CraftListSidebar.tsx
+++ b/playgrounds/ui-craft-playground/app/(navigation)/components/CraftListSidebar.tsx
@@ -1,0 +1,49 @@
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarTrigger,
+} from '@/shadcn-components/ui/sidebar';
+import Link from 'next/link';
+import { craftMetaMap } from '../data/craftMeta';
+
+export function CraftListSidebar() {
+  return (
+    <Sidebar>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarGroupLabel>ui-crafts</SidebarGroupLabel>
+          <SidebarGroupContent>
+            <SidebarMenu>
+              {Array.from(craftMetaMap.entries()).map(([id, craft]) => (
+                <SidebarMenuItem key={id}>
+                  <SidebarMenuButton asChild>
+                    <Link href={`/craft/${id}`}>
+                      <span>{craft.name}</span>
+                    </Link>
+                  </SidebarMenuButton>
+                </SidebarMenuItem>
+              ))}
+            </SidebarMenu>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+    </Sidebar>
+  );
+}
+
+export function CraftListSidebarProvider({
+  children,
+}: { children: React.ReactNode }) {
+  return <SidebarProvider>{children}</SidebarProvider>;
+}
+
+export function CraftListSidebarTrigger() {
+  return <SidebarTrigger />;
+}

--- a/playgrounds/ui-craft-playground/app/(navigation)/data/craftMeta.tsx
+++ b/playgrounds/ui-craft-playground/app/(navigation)/data/craftMeta.tsx
@@ -1,0 +1,24 @@
+import { FfxivJobIconsLoopUsingFlubber } from '@siluat/ui-craft/react/ffxiv-job-icons-loop-using-flubber';
+import { FfxivJobIconsLoopUsingGooeyEffect } from '@siluat/ui-craft/react/ffxiv-job-icons-loop-using-gooey-effect';
+
+interface CraftMeta {
+  name: string;
+  component: React.ReactNode;
+}
+
+export const craftMetaMap = new Map<string, CraftMeta>([
+  [
+    'ffxiv-job-icon-loop-using-flubber',
+    {
+      name: 'FFXIV Job Icons Loop (flubber)',
+      component: <FfxivJobIconsLoopUsingFlubber />,
+    },
+  ],
+  [
+    'ffxiv-job-icon-loop-using-gooey-effect',
+    {
+      name: 'FFXIV Job Icons Loop (gooey)',
+      component: <FfxivJobIconsLoopUsingGooeyEffect />,
+    },
+  ],
+]);

--- a/playgrounds/ui-craft-playground/app/(navigation)/data/craftMeta.tsx
+++ b/playgrounds/ui-craft-playground/app/(navigation)/data/craftMeta.tsx
@@ -3,7 +3,7 @@ import { FfxivJobIconsLoopUsingGooeyEffect } from '@siluat/ui-craft/react/ffxiv-
 
 interface CraftMeta {
   name: string;
-  component: React.ReactNode;
+  render: () => React.ReactNode;
 }
 
 export const craftMetaMap = new Map<string, CraftMeta>([
@@ -11,14 +11,14 @@ export const craftMetaMap = new Map<string, CraftMeta>([
     'ffxiv-job-icon-loop-using-flubber',
     {
       name: 'FFXIV Job Icons Loop (flubber)',
-      component: <FfxivJobIconsLoopUsingFlubber />,
+      render: () => <FfxivJobIconsLoopUsingFlubber />,
     },
   ],
   [
     'ffxiv-job-icon-loop-using-gooey-effect',
     {
       name: 'FFXIV Job Icons Loop (gooey)',
-      component: <FfxivJobIconsLoopUsingGooeyEffect />,
+      render: () => <FfxivJobIconsLoopUsingGooeyEffect />,
     },
   ],
 ]);

--- a/playgrounds/ui-craft-playground/app/craft/[slug]/page.tsx
+++ b/playgrounds/ui-craft-playground/app/craft/[slug]/page.tsx
@@ -16,7 +16,7 @@ export default async function Page({
         <h1 className="w-full text-center">{craft.name}</h1>
       </header>
       <div className="flex flex-1 items-center justify-center">
-        {craft.component}
+        {craft.render()}
       </div>
     </div>
   );

--- a/playgrounds/ui-craft-playground/app/craft/[slug]/page.tsx
+++ b/playgrounds/ui-craft-playground/app/craft/[slug]/page.tsx
@@ -1,0 +1,23 @@
+import { craftMetaMap } from '@/app/(navigation)/data/craftMeta';
+import { notFound } from 'next/navigation';
+export default async function Page({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const craft = craftMetaMap.get(slug);
+  if (!craft) {
+    notFound();
+  }
+  return (
+    <div className="flex flex-col w-full h-full">
+      <header className="flex p-4">
+        <h1 className="w-full text-center">{craft.name}</h1>
+      </header>
+      <div className="flex flex-1 items-center justify-center">
+        {craft.component}
+      </div>
+    </div>
+  );
+}

--- a/playgrounds/ui-craft-playground/app/layout.tsx
+++ b/playgrounds/ui-craft-playground/app/layout.tsx
@@ -14,6 +14,7 @@ export default function RootLayout({
     <html lang="en">
       <head>
         <title>UI Craft Playground</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
       </head>
       <body>
         <CraftListSidebarProvider>

--- a/playgrounds/ui-craft-playground/app/layout.tsx
+++ b/playgrounds/ui-craft-playground/app/layout.tsx
@@ -1,3 +1,8 @@
+import {
+  CraftListSidebar,
+  CraftListSidebarProvider,
+  CraftListSidebarTrigger,
+} from './(navigation)/components/CraftListSidebar';
 import './globals.css';
 
 export default function RootLayout({
@@ -7,7 +12,20 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <head>
+        <title>UI Craft Playground</title>
+      </head>
+      <body>
+        <CraftListSidebarProvider>
+          <CraftListSidebar />
+          <div className="flex w-full relative">
+            <div className="absolute top-0 left-0">
+              <CraftListSidebarTrigger />
+            </div>
+            <main className="flex-1">{children}</main>
+          </div>
+        </CraftListSidebarProvider>
+      </body>
     </html>
   );
 }

--- a/playgrounds/ui-craft-playground/app/page.tsx
+++ b/playgrounds/ui-craft-playground/app/page.tsx
@@ -1,9 +1,7 @@
-import { FfxivJobIconsLoopUsingFlubber } from '@siluat/ui-craft/react/ffxiv-job-icons-loop-using-flubber';
 export default function Page() {
   return (
-    <main className="flex flex-col items-center justify-center h-screen">
-      <span>FFXIV Job Icons Loop using Flubber</span>
-      <FfxivJobIconsLoopUsingFlubber />
-    </main>
+    <div className="flex items-center justify-center w-full h-full">
+      <span>Select a component from the sidebar</span>
+    </div>
   );
 }


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
  - 사이드바 내비게이션을 도입하여 다양한 UI 공예 항목들을 쉽게 탐색할 수 있게 되었습니다.
  - 선택한 공예의 세부 정보를 보여주는 페이지가 새롭게 구현되었습니다.
  - 메인 레이아웃이 개선되어 페이지 제목이 "UI Craft Playground"로 설정되었으며, 사이드바에서 컴포넌트를 선택하라는 안내 문구가 적용되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->