### PR TITLE
✨ (dotori-note): add theme setting feature

### DIFF
--- a/apps/dotori-note/src/app/providers/InitTheme.astro
+++ b/apps/dotori-note/src/app/providers/InitTheme.astro
@@ -1,11 +1,38 @@
 <script is:inline>
+  // asdsd
+
+  const THEMES = ['light', 'dark'];
+  const THEME_STORAGE_KEY = 'theme';
+  const MEDIA_QUERY = window.matchMedia('(prefers-color-scheme: dark)');
+
+  /**
+   * Requires the `dark` variant to be defined in global CSS
+   * @see https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually
+   */
   function toggleDarkMode(isDark) {
     document.documentElement.classList.toggle('dark', isDark);
   }
 
-  const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
+  function getStoredThemeSetting() {
+    const value = localStorage.getItem(THEME_STORAGE_KEY);
+    return typeof value === 'string' && THEMES.includes(value) ? value : undefined;
+  }
+  
+  const storedThemeSetting = getStoredThemeSetting();
 
-  toggleDarkMode(mediaQuery.matches);
+  if (storedThemeSetting) {
+    // use stored theme setting
+    toggleDarkMode(storedThemeSetting === 'dark');
+  } else {
+    // use system theme setting
+    toggleDarkMode(MEDIA_QUERY.matches);
+  }
 
-  mediaQuery.addEventListener('change', (event) => toggleDarkMode(event.matches));
+  MEDIA_QUERY.addEventListener('change', (event) => {
+    if (getStoredThemeSetting()) {
+      return;
+    }
+
+    toggleDarkMode(event.matches);
+  });
 </script>

--- a/apps/dotori-note/src/app/providers/InitTheme.astro
+++ b/apps/dotori-note/src/app/providers/InitTheme.astro
@@ -1,6 +1,4 @@
 <script is:inline>
-  // asdsd
-
   const THEMES = ['light', 'dark'];
   const THEME_STORAGE_KEY = 'theme';
   const MEDIA_QUERY = window.matchMedia('(prefers-color-scheme: dark)');

--- a/apps/dotori-note/src/app/styles/global.css
+++ b/apps/dotori-note/src/app/styles/global.css
@@ -4,3 +4,5 @@
 @theme {
   --font-noto-sans-kr: 'Noto Sans KR Variable', 'sans-serif';
 }
+
+@custom-variant dark (&:is(.dark *));

--- a/apps/dotori-note/src/widgets/header/react/GlobalMenu.tsx
+++ b/apps/dotori-note/src/widgets/header/react/GlobalMenu.tsx
@@ -22,13 +22,12 @@ import {
   Sun,
 } from 'lucide-react';
 import { useState } from 'react';
+import { useThemeSetting } from './use-theme-setting';
 
 export function GlobalMenu() {
   const [open, setOpen] = useState(false);
-
-  const preventDefault = (event: Event) => {
-    event.preventDefault();
-  };
+  const { currentThemeSetting, switchThemeSetting, ThemeSetting } =
+    useThemeSetting();
 
   return (
     /**
@@ -37,6 +36,7 @@ export function GlobalMenu() {
     <DropdownMenu open={open} onOpenChange={setOpen}>
       <DropdownMenuTrigger asChild>
         <Button
+          aria-label="Global Menu"
           variant="outline"
           className="cursor-pointer dark:bg-zinc-900"
           onClick={() => setOpen(!open)}
@@ -77,27 +77,28 @@ export function GlobalMenu() {
           </DropdownMenuItem>
         </DropdownMenuGroup>
         <DropdownMenuSeparator />
-        <DropdownMenuRadioGroup value="auto">
+        <DropdownMenuRadioGroup value={currentThemeSetting}>
           <DropdownMenuLabel className="text-zinc-400 dark:text-zinc-500 flex items-center gap-2">
             테마 설정
           </DropdownMenuLabel>
           <DropdownMenuSeparator />
-          <DropdownMenuRadioItem value="auto" onSelect={preventDefault}>
+          <DropdownMenuRadioItem
+            value={ThemeSetting.Auto}
+            onSelect={() => switchThemeSetting(ThemeSetting.Auto)}
+          >
             <MonitorCog className="w-4 h-4" />
             자동
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem
-            value="light"
-            onSelect={preventDefault}
-            disabled
+            value={ThemeSetting.Light}
+            onSelect={() => switchThemeSetting(ThemeSetting.Light)}
           >
             <Sun className="w-4 h-4" />
             라이트
           </DropdownMenuRadioItem>
           <DropdownMenuRadioItem
-            value="dark"
-            onSelect={preventDefault}
-            disabled
+            value={ThemeSetting.Dark}
+            onSelect={() => switchThemeSetting(ThemeSetting.Dark)}
           >
             <Moon className="w-4 h-4" />
             다크

--- a/apps/dotori-note/src/widgets/header/react/use-theme-setting.ts
+++ b/apps/dotori-note/src/widgets/header/react/use-theme-setting.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from 'react';
+
+const ThemeSetting = {
+  Light: 'light',
+  Dark: 'dark',
+  Auto: 'auto',
+} as const;
+
+type ThemeSetting = (typeof ThemeSetting)[keyof typeof ThemeSetting];
+
+const THEME_STORAGE_KEY = 'theme';
+
+/**
+ * Requires the `dark` variant to be defined in global CSS
+ * @see https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually
+ */
+function toogleDarkMode(isDark: boolean) {
+  document.documentElement.classList.toggle('dark', isDark);
+}
+
+export function useThemeSetting() {
+  const [themeSetting, setThemeSetting] = useState<ThemeSetting>(
+    ThemeSetting.Auto,
+  );
+
+  useEffect(() => {
+    const storedThemeSetting = localStorage.getItem(THEME_STORAGE_KEY);
+    if (
+      typeof storedThemeSetting === 'string' &&
+      Object.values(ThemeSetting).includes(storedThemeSetting as ThemeSetting)
+    ) {
+      setThemeSetting(storedThemeSetting as ThemeSetting);
+    } else {
+      setThemeSetting(ThemeSetting.Auto);
+    }
+  });
+
+  const switchThemeSetting = (themeSetting: ThemeSetting) => {
+    if (themeSetting === ThemeSetting.Auto) {
+      toogleDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
+      localStorage.removeItem(THEME_STORAGE_KEY);
+    } else {
+      toogleDarkMode(themeSetting === ThemeSetting.Dark);
+      localStorage.setItem(THEME_STORAGE_KEY, themeSetting);
+    }
+    setThemeSetting(themeSetting);
+  };
+
+  return {
+    ThemeSetting,
+    currentThemeSetting: themeSetting,
+    switchThemeSetting,
+  };
+}

--- a/apps/dotori-note/src/widgets/header/react/use-theme-setting.ts
+++ b/apps/dotori-note/src/widgets/header/react/use-theme-setting.ts
@@ -14,7 +14,7 @@ const THEME_STORAGE_KEY = 'theme';
  * Requires the `dark` variant to be defined in global CSS
  * @see https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually
  */
-function toogleDarkMode(isDark: boolean) {
+function toggleDarkMode(isDark: boolean) {
   document.documentElement.classList.toggle('dark', isDark);
 }
 
@@ -33,14 +33,14 @@ export function useThemeSetting() {
     } else {
       setThemeSetting(ThemeSetting.Auto);
     }
-  });
+  }, []);
 
   const switchThemeSetting = (themeSetting: ThemeSetting) => {
     if (themeSetting === ThemeSetting.Auto) {
-      toogleDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
+      toggleDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches);
       localStorage.removeItem(THEME_STORAGE_KEY);
     } else {
-      toogleDarkMode(themeSetting === ThemeSetting.Dark);
+      toggleDarkMode(themeSetting === ThemeSetting.Dark);
       localStorage.setItem(THEME_STORAGE_KEY, themeSetting);
     }
     setThemeSetting(themeSetting);

--- a/apps/dotori-note/tests/header-switch-theme.spec.ts
+++ b/apps/dotori-note/tests/header-switch-theme.spec.ts
@@ -1,0 +1,186 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { BrowserContext, Locator, Page } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+
+const ThemeSettingLabel = {
+  Dark: '다크',
+  Light: '라이트',
+  Auto: '자동',
+} as const;
+
+const TIMEOUT = {
+  NAVIGATION: 10000, // Timeout for page navigation and element waiting
+  ANIMATION: 1000, // Wait time for animations to complete
+  CLICK_DELAY: 300, // Wait time before and after clicks
+  THEME_CHANGE: 500, // Wait time for theme change to apply
+};
+
+// Create screenshot directory if it doesn't exist
+const screenshotDir = path.join(process.cwd(), 'test-results/screenshots');
+if (!fs.existsSync(screenshotDir)) {
+  fs.mkdirSync(screenshotDir, { recursive: true });
+}
+
+/**
+ * Initialize stored theme in localStorage
+ */
+async function initStoredTheme(
+  context: BrowserContext,
+  storedTheme: 'dark' | 'light' | undefined,
+) {
+  await context.clearCookies();
+  await context.addInitScript((theme) => {
+    localStorage.clear();
+    sessionStorage.clear();
+    if (theme) {
+      localStorage.setItem('theme', theme);
+    }
+  }, storedTheme);
+}
+
+/**
+ * Open theme options menu and return elements and utility function
+ */
+async function openThemeOptions(page: Page) {
+  await page.waitForLoadState('networkidle');
+
+  // Click the global menu button
+  const globalMenuButton = page.getByRole('button', { name: 'Global Menu' });
+  await globalMenuButton.waitFor({
+    state: 'visible',
+    timeout: TIMEOUT.NAVIGATION,
+  });
+
+  try {
+    await globalMenuButton.click({ force: true, timeout: TIMEOUT.NAVIGATION });
+  } catch (error) {
+    console.log('First click attempt failed, retrying:', error);
+    await page.reload();
+    await page.waitForLoadState('networkidle');
+    const retryButton = page.getByRole('button', { name: 'Global Menu' });
+    await retryButton.waitFor({
+      state: 'visible',
+      timeout: TIMEOUT.NAVIGATION,
+    });
+    await retryButton.click({ timeout: TIMEOUT.NAVIGATION });
+  }
+
+  // Wait for menu animation to complete
+  await page.waitForTimeout(TIMEOUT.ANIMATION);
+
+  // Find menu container and option elements
+  const menuContainer = page.locator('[role="menu"]');
+  await menuContainer.waitFor({
+    state: 'visible',
+    timeout: TIMEOUT.NAVIGATION,
+  });
+
+  // Define theme option elements
+  const themeOptions = {
+    autoThemeOption: menuContainer.getByRole('menuitemradio', {
+      name: ThemeSettingLabel.Auto,
+      exact: true,
+    }),
+    lightThemeOption: menuContainer.getByRole('menuitemradio', {
+      name: ThemeSettingLabel.Light,
+      exact: true,
+    }),
+    darkThemeOption: menuContainer.getByRole('menuitemradio', {
+      name: ThemeSettingLabel.Dark,
+      exact: true,
+    }),
+  };
+
+  // Wait for all menu items to load
+  await themeOptions.autoThemeOption.waitFor({
+    state: 'visible',
+    timeout: TIMEOUT.NAVIGATION,
+  });
+
+  // Safe click function with retry mechanism
+  const safeClick = async (option: Locator) => {
+    await option.waitFor({ state: 'visible', timeout: TIMEOUT.NAVIGATION });
+
+    try {
+      await option.focus();
+      await page.waitForTimeout(TIMEOUT.CLICK_DELAY);
+      await option.click({ timeout: TIMEOUT.NAVIGATION, force: true });
+    } catch (error) {
+      console.log('Click failed, using JavaScript click instead:', error);
+      // Try JavaScript click as fallback
+      await page.evaluate((selector) => {
+        const elements = document.querySelectorAll(selector);
+        if (elements.length > 0) {
+          (elements[0] as HTMLElement).click();
+        }
+      }, option.toString());
+    }
+    await page.waitForTimeout(TIMEOUT.CLICK_DELAY);
+  };
+
+  return {
+    ...themeOptions,
+    safeClick,
+  };
+}
+
+test.describe('Theme Switching in Header', () => {
+  test.beforeEach(async ({ context, page }) => {
+    await context.clearPermissions();
+    await context.clearCookies();
+    await page.goto('/', { waitUntil: 'networkidle' });
+    await page.waitForFunction(() => document.readyState === 'complete');
+  });
+
+  test.afterEach(async ({ page }, testInfo) => {
+    if (testInfo.status !== 'passed') {
+      const screenshotPath = path.join(
+        screenshotDir,
+        `test-failed-${testInfo.title.replace(/\s+/g, '-')}-${Date.now()}.png`,
+      );
+      await page.screenshot({ path: screenshotPath });
+      console.log(`Test failed: Screenshot saved at ${screenshotPath}`);
+    }
+  });
+
+  test('Changes to dark theme when dark theme option is clicked', async ({
+    page,
+    context,
+  }) => {
+    await initStoredTheme(context, undefined);
+    await page.reload({ waitUntil: 'networkidle' });
+
+    const { darkThemeOption, safeClick } = await openThemeOptions(page);
+    await safeClick(darkThemeOption);
+    await expect(page.locator('html')).toHaveClass('dark');
+  });
+
+  test('Changes to light theme when light theme option is clicked', async ({
+    page,
+    context,
+  }) => {
+    await initStoredTheme(context, undefined);
+    await page.reload({ waitUntil: 'networkidle' });
+
+    const { lightThemeOption, safeClick } = await openThemeOptions(page);
+    await safeClick(lightThemeOption);
+    await expect(page.locator('html')).not.toHaveClass('dark');
+  });
+
+  test('Changes theme according to system preference when auto theme is selected', async ({
+    page,
+    context,
+  }) => {
+    await initStoredTheme(context, 'dark');
+    await page.reload({ waitUntil: 'networkidle' });
+
+    await expect(page.locator('html')).toHaveClass('dark');
+    const { autoThemeOption, safeClick } = await openThemeOptions(page);
+    await safeClick(autoThemeOption);
+    await page.emulateMedia({ colorScheme: 'light' });
+
+    await page.waitForTimeout(TIMEOUT.THEME_CHANGE);
+    await expect(page.locator('html')).not.toHaveClass('dark');
+  });
+});

--- a/apps/dotori-note/tests/initialize-theme.spec.ts
+++ b/apps/dotori-note/tests/initialize-theme.spec.ts
@@ -6,7 +6,7 @@ test.describe('Initialize Theme', () => {
   }) => {
     await page.emulateMedia({ colorScheme: 'dark' });
     await page.goto('/');
-    await expect(page.locator('html')).toHaveClass(/dark/);
+    await expect(page.locator('html')).toHaveClass('dark');
   });
 
   test('should initialize with light theme when system prefers light mode', async ({
@@ -14,7 +14,7 @@ test.describe('Initialize Theme', () => {
   }) => {
     await page.emulateMedia({ colorScheme: 'light' });
     await page.goto('/');
-    await expect(page.locator('html')).not.toHaveClass(/dark/);
+    await expect(page.locator('html')).not.toHaveClass('dark');
   });
 
   test('should update to dark theme when system color scheme changes to dark', async ({
@@ -22,10 +22,10 @@ test.describe('Initialize Theme', () => {
   }) => {
     await page.emulateMedia({ colorScheme: 'light' });
     await page.goto('/');
-    await expect(page.locator('html')).not.toHaveClass(/dark/);
+    await expect(page.locator('html')).not.toHaveClass('dark');
 
     await page.emulateMedia({ colorScheme: 'dark' });
-    await expect(page.locator('html')).toHaveClass(/dark/);
+    await expect(page.locator('html')).toHaveClass('dark');
   });
 
   test('should update to light theme when system color scheme changes to light', async ({
@@ -33,19 +33,20 @@ test.describe('Initialize Theme', () => {
   }) => {
     await page.emulateMedia({ colorScheme: 'dark' });
     await page.goto('/');
-    await expect(page.locator('html')).toHaveClass(/dark/);
+    await expect(page.locator('html')).toHaveClass('dark');
 
     await page.emulateMedia({ colorScheme: 'light' });
-    await expect(page.locator('html')).not.toHaveClass(/dark/);
+    await expect(page.locator('html')).not.toHaveClass('dark');
   });
-});
 
-test.describe('Theme Setting', () => {
-  test('should update to dark theme when theme setting is dark', async ({
+  test('if theme setting stored, should not change theme when prefers-color-scheme is changed', async ({
     page,
   }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('theme', 'dark');
+    });
     await page.goto('/');
-    const globalMenu = page.getByRole('button', { name: 'Global Menu' });
-    await expect(globalMenu).toBeVisible();
+    await page.emulateMedia({ colorScheme: 'light' });
+    await expect(page.locator('html')).toHaveClass('dark');
   });
 });


### PR DESCRIPTION
### TL;DR

Implemented theme switching functionality with persistent user preferences.

### What changed?

- Enhanced the theme system to support user-selected themes (light/dark/auto)
- Added theme persistence using localStorage
- Implemented a React hook `useThemeSetting` to manage theme state
- Updated the GlobalMenu component with working theme toggle options
- Added comprehensive tests for theme initialization and switching
- Added a custom dark variant in global CSS

### How to test?

1. Open the application and click on the Global Menu button
2. Try switching between light, dark, and auto theme options
3. Refresh the page to verify theme persistence
4. Change your system theme settings to verify the auto theme option works correctly

### Why make this change?

This change improves user experience by allowing them to choose their preferred theme rather than being limited to the system default. The theme preference is now persisted between sessions, ensuring a consistent experience. The implementation follows best practices with proper separation of concerns through a dedicated hook and comprehensive test coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 업그레이드된 테마 관리 방식으로 사용자 선호도를 저장하고, 시스템 기본 설정과 조화를 이루어 테마가 적용됩니다.
  - 메뉴에서 자동, 라이트, 다크 모드로 손쉽게 전환할 수 있도록 개선되었으며, 접근성이 강화되었습니다.
  - 새로운 테마 전환 기능 도입으로 설정 변경이 더욱 원활해졌습니다.
  
- **Style**
  - 다크 모드 전용 스타일링 옵션이 추가되어 테마 전환 시 시각적 경험이 향상되었습니다.

- **Tests**
  - 테마 전환 및 초기화 기능의 신뢰성을 높이기 위해 다양한 테스트 케이스가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->