### PR TITLE
💄 (dotori-note): add view transition styles and enhance theme toggle functionality

### DIFF
--- a/apps/dotori-note/src/app/styles/global.css
+++ b/apps/dotori-note/src/app/styles/global.css
@@ -1,5 +1,6 @@
 @import 'tailwindcss';
 @import '@siluat/shadcn-ui/globals.css';
+@import './view-transition.css';
 @plugin "@tailwindcss/typography";
 @theme {
   --font-noto-sans-kr: 'Noto Sans KR Variable', 'sans-serif';

--- a/apps/dotori-note/src/app/styles/view-transition.css
+++ b/apps/dotori-note/src/app/styles/view-transition.css
@@ -1,0 +1,42 @@
+::view-transition-group(root) {
+  animation-duration: 0.7s;
+  animation-timing-function: cubic-bezier(0.77, 0, 0.175, 1);
+  animation-fill-mode: forwards;
+}
+
+@media (prefers-reduced-motion) {
+  ::view-transition-group(root) {
+    animation: none;
+  }
+}
+
+::view-transition-new(root) {
+  animation-name: reveal-light;
+}
+
+::view-transition-old(root),
+.dark::view-transition-old(root) {
+  animation: none;
+  z-index: -1;
+}
+.dark::view-transition-new(root) {
+  animation-name: reveal-dark;
+}
+
+@keyframes reveal-dark {
+  from {
+    clip-path: polygon(0% 0%, 100% 0%, 100% 0%, 0% 0%);
+  }
+  to {
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+}
+
+@keyframes reveal-light {
+  from {
+    clip-path: polygon(0% 0%, 100% 0%, 100% 0%, 0% 0%);
+  }
+  to {
+    clip-path: polygon(0% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+}

--- a/apps/dotori-note/src/widgets/header/react/use-theme-setting.ts
+++ b/apps/dotori-note/src/widgets/header/react/use-theme-setting.ts
@@ -15,7 +15,13 @@ const THEME_STORAGE_KEY = 'theme';
  * @see https://tailwindcss.com/docs/dark-mode#toggling-dark-mode-manually
  */
 function toggleDarkMode(isDark: boolean) {
-  document.documentElement.classList.toggle('dark', isDark);
+  if (!document.startViewTransition) {
+    document.documentElement.classList.toggle('dark', isDark);
+  } else {
+    document.startViewTransition(() => {
+      document.documentElement.classList.toggle('dark', isDark);
+    });
+  }
 }
 
 export function useThemeSetting() {


### PR DESCRIPTION
### TL;DR

Added view transitions for theme switching with a smooth animation effect.

### What changed?

- Created a new CSS file `view-transition.css` with transition animations for theme switching
- Imported the new CSS file in the global styles
- Enhanced the `toggleDarkMode` function to use the View Transitions API when available

### How to test?

1. Toggle between light and dark themes using the theme switcher
2. Observe the smooth transition animation when switching themes
3. Verify that the animation works correctly in browsers that support the View Transitions API
4. Confirm that browsers without View Transitions API support still toggle themes correctly without animation

### Why make this change?

This change improves the user experience by adding a polished animation when switching between light and dark themes. The implementation uses the modern View Transitions API when available, with a fallback for browsers that don't support it. The animation provides visual continuity during theme changes, making the interface feel more responsive and refined.