### PR TITLE
🔧 (noumenon-gleaner): add Noumenon Gleaner package with build scripts, postbuild script for executable management, and playground for testing

### DIFF
--- a/packages/noumenon-gleaner/.gitignore
+++ b/packages/noumenon-gleaner/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# bin directory
+bin/

--- a/packages/noumenon-gleaner/package.json
+++ b/packages/noumenon-gleaner/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "noumenon-gleaner",
+  "private": true,
+  "type": "module",
+  "version": "0.1.0",
+  "description": "Data extraction tool for Noumenon project",
+  "bin": {
+    "noumenon-gleaner": "./bin/noumenon-gleaner"
+  },
+  "scripts": {
+    "prepare": "npm run build",
+    "build": "cargo build --release && npm run postbuild",
+    "postbuild": "node scripts/postbuild.js"
+  }
+}

--- a/packages/noumenon-gleaner/scripts/postbuild.js
+++ b/packages/noumenon-gleaner/scripts/postbuild.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const binDir = path.join(__dirname, '..', 'bin');
+const targetDir = path.join(__dirname, '..', 'target', 'release');
+
+// Ensure bin directory exists
+if (!fs.existsSync(binDir)) {
+  fs.mkdirSync(binDir, { recursive: true });
+}
+
+// Platform-specific executable names
+const isWindows = os.platform() === 'win32';
+const executableName = isWindows ? 'noumenon-gleaner.exe' : 'noumenon-gleaner';
+const sourcePath = path.join(targetDir, executableName);
+const targetPath = path.join(binDir, executableName);
+
+// Copy the executable to bin directory
+if (fs.existsSync(sourcePath)) {
+  fs.copyFileSync(sourcePath, targetPath);
+
+  // Make executable on Unix systems
+  if (!isWindows) {
+    fs.chmodSync(targetPath, '755');
+  }
+
+  console.log(`✓ Copied ${executableName} to bin/noumenon-gleaner`);
+} else {
+  console.error(`✗ Source executable not found: ${sourcePath}`);
+  process.exit(1);
+}
+
+// Create Windows batch file for cmd compatibility
+if (isWindows) {
+  const batchContent = `@echo off
+"%~dp0noumenon-gleaner.exe" %*
+`;
+  fs.writeFileSync(path.join(binDir, 'noumenon-gleaner.cmd'), batchContent);
+  console.log('✓ Created Windows batch file: bin/noumenon-gleaner.cmd');
+}

--- a/playgrounds/noumenon-gleaner-runner/README.md
+++ b/playgrounds/noumenon-gleaner-runner/README.md
@@ -1,0 +1,16 @@
+# Noumenon Gleaner Runner
+
+Noumenon Gleaner 실행 테스트
+
+## Usage
+
+```bash
+$ pnpm test
+```
+
+Expected output:
+
+```bash
+# 다음과 같은 메시지가 출력된다.
+Gleaner is not implemented yet
+```

--- a/playgrounds/noumenon-gleaner-runner/package.json
+++ b/playgrounds/noumenon-gleaner-runner/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "noumenon-gleaner-runner",
+  "version": "1.0.0",
+  "description": "Testing playground for Noumenon Gleaner",
+  "scripts": {
+    "test": "npx noumenon-gleaner"
+  },
+  "devDependencies": {
+    "noumenon-gleaner": "workspace:*"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,8 @@ importers:
         specifier: ^19.0.4
         version: 19.0.4(@types/react@19.0.11)
 
+  packages/noumenon-gleaner: {}
+
   packages/shadcn-ui:
     dependencies:
       '@radix-ui/react-dialog':
@@ -208,6 +210,12 @@ importers:
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@20.17.28)(happy-dom@17.4.4)(jiti@2.4.2)(lightningcss@1.29.2)(msw@2.7.3(@types/node@20.17.28)(typescript@5.8.2))(yaml@2.7.1)
+
+  playgrounds/noumenon-gleaner-runner:
+    devDependencies:
+      noumenon-gleaner:
+        specifier: workspace:*
+        version: link:../../packages/noumenon-gleaner
 
   playgrounds/ui-craft-playground:
     dependencies:


### PR DESCRIPTION
### TL;DR

Added npm package configuration for the Rust-based Noumenon Gleaner tool with build scripts and a test playground.

### What changed?

- Added `.gitignore` entry to exclude the `bin/` directory
- Created `package.json` for the Noumenon Gleaner with build scripts
- Added a `postbuild.js` script that:
  - Copies the compiled Rust executable to the bin directory
  - Makes the file executable on Unix systems
  - Creates a batch file for Windows compatibility
- Created a test playground (`noumenon-gleaner-runner`) with:
  - README with usage instructions
  - Package configuration that depends on the Gleaner tool

### How to test?

1. Build the Gleaner tool:
   ```bash
   cd packages/noumenon-gleaner
   pnpm build
   ```

2. Run the test playground:
   ```bash
   cd playgrounds/noumenon-gleaner-runner
   pnpm test
   ```

3. Verify the output shows "Gleaner is not implemented yet"

### Why make this change?

This change sets up the necessary npm package structure to make the Rust-based Noumenon Gleaner tool easily consumable within the JavaScript ecosystem. The build scripts handle cross-platform compatibility, and the test playground provides a simple way to verify the tool works correctly after building.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * Noumenon Gleaner 패키지 및 실행 파일이 추가되었습니다.
  * Noumenon Gleaner Runner 테스트 환경이 도입되었습니다.

* **문서**
  * Noumenon Gleaner Runner에 대한 README 파일이 추가되었습니다.

* **작업**
  * Noumenon Gleaner 패키지의 .gitignore가 bin 디렉터리를 무시하도록 업데이트되었습니다.
  * 빌드 후 실행 파일 복사 및 권한 설정을 자동화하는 postbuild 스크립트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->