### PR TITLE
💄 (dotori-note): add Blockquote component for enhanced note formatting

### DIFF
--- a/apps/dotori-note/README.md
+++ b/apps/dotori-note/README.md
@@ -4,24 +4,25 @@
 
 ## 프로젝트 구조
 
-Astro 프로젝트 기본 구조와 FSD(Feature-Sliced Design) 구조를 조합하여 다음과 같은 레이어 규칙을 따른다.
+~~Astro 프로젝트 기본 구조와 FSD(Feature-Sliced Design) 구조를 조합하여 다음과 같은 레이어 규칙을 따른다.~~  
+FSD 구조를 폐기하고 기존 구조였던 기능별 구조로 점진적으로 변경한다.
 
-| 레이어 | 컨벤션 | 부가 설명 |
-| --- | --- | --- |
-| `notes` | Astro | MDX 형식의 콘텐츠 파일 관리 |
-| `src/app` | FSD | |
-| `src/pages` | Astro | |
-| `src/widgets` | FSD | |
-| `src/features` | FSD | |
-| `src/entities` | FSD | |
-| `src/shared` | FSD | |
+### 원칙
 
-- FSD 레이어 규칙과 동일하게 모든 레이어는 하위 레이어만을 참조할 수 있다.
+- `src` 폴더 하위의 폴더 목록만을 보고 기능들의 목록을 파악할 수 있어야 한다.
+- `src` 폴더 하위의 폴더 내부에는 폴더 중첩을 허용하지 않는다.
 
-### 참고
-
-- [Astro 프로젝트 구조](https://docs.astro.build/en/basics/project-structure/)
-- [Feature-Sliced Design](https://feature-sliced.github.io/documentation/docs/get-started/overview#concepts)
+| 폴더                | 컨벤션 | 부가 설명                              |
+| ------------------- | ------ | -------------------------------------- |
+| `notes`             | Astro  | MDX 형식의 콘텐츠 파일                 |
+| `src/mdx-custom-ui` | -      | MDX 콘텐츠 렌더링에 사용하는 커스텀 UI |
+| `src/pages`         | Astro  |                                        |
+| --                  | --     | --                                     |
+| `src/app`           | FSD    | deprecated                             |
+| `src/widgets`       | FSD    | deprecated                             |
+| `src/features`      | FSD    | deprecated                             |
+| `src/entities`      | FSD    | deprecated                             |
+| `src/shared`        | FSD    | deprecated                             |
 
 ## 기술/패키지 의존성
 

--- a/apps/dotori-note/src/mdx-custom-ui/Blockquote.astro
+++ b/apps/dotori-note/src/mdx-custom-ui/Blockquote.astro
@@ -1,0 +1,10 @@
+---
+const props = Astro.props;
+const textStyle = 'dark:text-zinc-200 not-italic font-normal';
+const borderStyle = 'border-l-6 border-purple-300 dark:border-purple-400/40';
+const hideQuotes = '[&_*]:before:content-none [&_*]:after:content-none';
+---
+
+<blockquote {...props} class={`bg-purple-300/10 dark:bg-purple-200/8 pr-4 ${textStyle} ${borderStyle} ${hideQuotes}`}>
+  <slot />
+</blockquote>

--- a/apps/dotori-note/src/pages/note/[id].astro
+++ b/apps/dotori-note/src/pages/note/[id].astro
@@ -1,6 +1,7 @@
 ---
 import ContentLayout from '@/app/layouts/ContentLayout.astro';
 import { getCollection, render } from 'astro:content';
+import Blockquote from '@/mdx-custom-ui/Blockquote.astro';
 
 export async function getStaticPaths() {
   const notes = await getCollection('notes');
@@ -15,5 +16,5 @@ const { Content } = await render(note);
 ---
 
 <ContentLayout title={note.data.title} description={note.data.description}>
-  <Content />
+  <Content components={{ blockquote: Blockquote }} />
 </ContentLayout>


### PR DESCRIPTION
# 💄 (dotori-note): Add custom Blockquote component for MDX content

- Created a new `Blockquote.astro` component in the `mdx-custom-ui` directory
- Applied custom styling with purple accents and dark mode support
- Integrated the component with MDX content rendering in note pages

# 📝 (dotori-note): Update project structure documentation

- Deprecated Feature-Sliced Design (FSD) structure in favor of feature-based organization
- Added new principles for folder structure:
  - Top-level folders should clearly represent features
  - No nested folders allowed within src subdirectories
- Updated folder convention table to include new `mdx-custom-ui` directory
- Marked previous FSD-related directories as deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MDX 렌더링 시 blockquote 요소에 맞춤 스타일이 적용된 새로운 Blockquote 컴포넌트가 추가되었습니다.

* **Documentation**
  * 프로젝트 폴더 구조와 관련 원칙이 변경된 내용을 README에 반영하였으며, FSD 구조가 더 이상 사용되지 않음을 명시했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->