### PR TITLE
💄 (dotori-note): enhance LastModifiedNotes component with improved layout and date display for better note context

### DIFF
--- a/apps/dotori-note/src/features/last-modified-notes/ui/LastModifiedNotes.astro
+++ b/apps/dotori-note/src/features/last-modified-notes/ui/LastModifiedNotes.astro
@@ -1,6 +1,5 @@
 ---
 import { getCollection } from 'astro:content';
-import { Badge } from '@siluat/shadcn-ui/components/badge';
 
 const notes = await getCollection('notes');
 const lastModifiedNotes = notes.sort((a, b) => {
@@ -10,20 +9,31 @@ const lastModifiedNotes = notes.sort((a, b) => {
 });
 ---
 
-<ul class="pl-0 flex flex-col">
+<ul class="pl-0 my-3 flex flex-col">
   {
     lastModifiedNotes.map((note) => (
-      <li class="my-3">
-        <a class="flex flex-col gap-2" href={`/note/${note.id}`}>
-          <span class="text-xl font-bold">
-            {note.data.title}
-          </span>
-          <div class="flex gap-1.5">
+      <li>
+        <a class="grid sm:grid-cols-2 grid-cols-1 gap-2 p-3 hover:bg-purple-200/50 dark:hover:bg-purple-200/20 rounded-md" href={`/note/${note.id}`}>
+          <div class="">
+            <span class="font-bold">
+              {note.data.title}
+            </span>
+          </div>
+          <div class="flex justify-between gap-1">
             {note.data.tags.map((tag) => (
-              <Badge className="rounded-full text-xs font-light text-zinc-500 dark:text-zinc-400" variant="secondary">
-                {tag}
-              </Badge>
+              <span class="text-sm text-zinc-500 dark:text-zinc-400">{tag}</span>
             ))}
+            <span class="text-sm text-right text-zinc-500 dark:text-zinc-400">
+              {note.data.modified ? new Date(note.data.modified).toLocaleDateString('ko-KR', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+              }) : new Date(note.data.created).toLocaleDateString('ko-KR', {
+                year: 'numeric',
+                month: '2-digit',
+                day: '2-digit',
+              })}
+            </span>
           </div>
         </a>
       </li>

--- a/apps/dotori-note/src/page-layouts/ContentLayout.astro
+++ b/apps/dotori-note/src/page-layouts/ContentLayout.astro
@@ -42,7 +42,7 @@ const modifiedText = modified ? new Date(modified).toLocaleDateString('ko-KR', {
     <GoogleTagProvider />
     <InitTheme />
   </head>
-  <body class="bg-zinc-50 dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 break-keep font-noto-sans-kr">
+  <body class="bg-zinc-50 dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 break-keep font-noto-sans-kr min-w-80">
     <Header />
     <main class="mx-auto max-w-screen-md">
       <article class="prose prose-zinc dark:prose-invert max-w-none px-6 py-12">

--- a/apps/dotori-note/src/page-layouts/DefaultLayout.astro
+++ b/apps/dotori-note/src/page-layouts/DefaultLayout.astro
@@ -30,7 +30,7 @@ const { title = '도토리 노트', description } = Astro.props;
     <GoogleTagProvider />
     <InitTheme />
   </head>
-  <body class="bg-zinc-50 dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 break-keep font-noto-sans-kr">
+  <body class="bg-zinc-50 dark:bg-zinc-900 text-zinc-900 dark:text-zinc-50 break-keep font-noto-sans-kr min-w-80">
     <Header />
     <main class="mx-auto max-w-screen-md">
       <slot />


### PR DESCRIPTION
### TL;DR

Redesigned the LastModifiedNotes component and added responsive layout improvements.

### What changed?

- Removed the Badge component from LastModifiedNotes and replaced it with simple text spans
- Redesigned the LastModifiedNotes list items with a grid layout for better responsiveness
- Added hover effects to list items with background color changes
- Added date display for each note showing either modified or created date
- Set minimum width (min-w-80) for body elements in both ContentLayout and DefaultLayout
- Improved spacing and margins in the LastModifiedNotes component

### How to test?

1. Navigate to pages displaying the LastModifiedNotes component
2. Verify the new grid layout displays correctly
3. Check that hover effects work properly on list items
4. Confirm dates are displayed correctly for each note
5. Test responsiveness by resizing the browser window
6. Ensure the minimum width constraint prevents layout issues on small screens

### Why make this change?

This redesign improves the user experience by providing a cleaner, more responsive layout for the LastModifiedNotes component. The addition of dates helps users better understand when content was last updated, while the hover effects improve interactivity. The minimum width constraint prevents layout issues on very small screens, ensuring a consistent experience across devices.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **스타일**
  * 최근 수정된 노트 목록의 레이아웃이 그리드 형태로 변경되고, 노트 제목, 태그, 날짜가 더 깔끔하게 정렬됩니다.
  * 태그가 배지 대신 일반 텍스트로 표시되며, 노트의 수정일 또는 생성일이 한국어 형식으로 함께 보여집니다.
  * 페이지 레이아웃의 최소 너비가 확대되어, 더 넓은 화면에서 내용이 잘려 보이지 않습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->