### PR TITLE
✨ (noumenon-gleaner): add Color type support in schema generation and TypeScript output

### DIFF
--- a/packages/noumenon-gleaner/docs/schema-generation-process.md
+++ b/packages/noumenon-gleaner/docs/schema-generation-process.md
@@ -63,11 +63,12 @@ int32,str,str,byte,bool
 
 ### 특별 타입
 
-| CSV 표기 | Rust FieldType | 설명                                |
-| -------- | -------------- | ----------------------------------- |
-| `Image`  | `Image`        | UI 이미지 파일 ID (그대로 보존)     |
-| `Row`    | `Row`          | 다른 테이블의 행 참조 (그대로 보존) |
-| `Key`    | `Key`          | 키 타입 식별자 (그대로 보존)        |
+| CSV 표기 | Rust FieldType | TypeScript 타입 | 설명                                      |
+| -------- | -------------- | --------------- | ----------------------------------------- |
+| `Image`  | `Image`        | `ImagePath`     | UI 이미지 파일 ID (그대로 보존)           |
+| `Row`    | `Row`          | `RowId`         | 다른 테이블의 행 참조 (그대로 보존)       |
+| `Key`    | `Key`          | `KeyString`     | 키 타입 식별자 (그대로 보존)              |
+| `Color`  | `Color`        | `ColorCode`     | 색상 코드 (number로 변환, 외부 파일 참조 안함) |
 
 #### Image 타입 사용 예시
 
@@ -85,6 +86,23 @@ int32,str,str,Image
 
 **생성되는 Rust FieldType**: `FieldType::Image`
 
+#### Color 타입 사용 예시
+
+`Color` 타입은 색상 코드를 나타내는 특별한 타입입니다. 이 타입은 외부 Color.csv 파일을 참조하지 않고 number 타입으로 처리됩니다.
+
+**CSV 예시:**
+
+```csv
+key,0,1,2
+#,Name,Description,TextColor
+int32,str,str,Color
+1,"Fire Element","Element of fire",16711680
+2,"Water Element","Element of water",255
+```
+
+**생성되는 Rust FieldType**: `FieldType::Color`
+**TypeScript 출력**: `ColorCode` (number alias)
+
 ### 커스텀 타입
 
 다음 조건을 만족하는 타입은 커스텀 타입으로 인식됩니다:
@@ -94,7 +112,7 @@ int32,str,str,Image
 
 커스텀 타입이 발견되면 동일한 디렉토리에서 `<타입명>.csv` 파일을 찾아 재귀적으로 스키마를 생성합니다.
 
-**주의**: `Image`와 `Row` 타입은 특별 타입으로 분류되어 커스텀 타입 탐색을 하지 않고 그대로 보존됩니다.
+**주의**: `Image`, `Row`, `Key`, `Color` 타입은 특별 타입으로 분류되어 커스텀 타입 탐색을 하지 않고 각각의 고유한 방식으로 처리됩니다.
 
 ## 스키마 생성 프로세스
 
@@ -210,8 +228,8 @@ pub enum FieldType {
     String, Int32, Uint32, Int16, Uint16,
     Byte, SByte, Float, Bool, Bit(u8),
 
-    // 특별 타입 (CSV: Image, Row, Key)
-    Image, Row, Key,
+    // 특별 타입 (CSV: Image, Row, Key, Color)
+    Image, Row, Key, Color,
 
     // 커스텀 타입 (CSV: ItemCategory, ClassJob 등)
     Custom(String),

--- a/packages/noumenon-gleaner/src/constants.rs
+++ b/packages/noumenon-gleaner/src/constants.rs
@@ -9,7 +9,7 @@ pub const CUSTOM_TYPE_PATTERNS: &[&str] = &[
 ];
 
 /// Special type names that have unique processing rules
-pub const SPECIAL_TYPES: &[&str] = &["Image", "Row", "Key"];
+pub const SPECIAL_TYPES: &[&str] = &["Image", "Row", "Key", "Color"];
 
 /// Header indicators for CSV row detection
 pub const FIELD_NAMES_HEADER: &str = "key";

--- a/packages/noumenon-gleaner/src/main.rs
+++ b/packages/noumenon-gleaner/src/main.rs
@@ -55,8 +55,9 @@ fn print_success(schema_name: &str) {
 fn print_error(error: &SchemaError) {
     eprintln!("Error: {}", error);
 
-    if let SchemaError::FileNotFound { path } = error {
+    if let SchemaError::FileNotFound { path, source_file } = error {
         eprintln!("\nRequired file not found: {}", path);
+        eprintln!("Referenced from: {}", source_file);
         eprintln!(
             "Make sure all referenced CSV files exist in the same directory as the input file."
         );

--- a/packages/noumenon-gleaner/src/schema/builder.rs
+++ b/packages/noumenon-gleaner/src/schema/builder.rs
@@ -639,4 +639,72 @@ mod tests {
         assert_eq!(schema.fields[3].name, "ref");
         assert_eq!(schema.fields[3].field_type, FieldType::Row);
     }
+
+    #[test]
+    fn test_color_type_parsing() {
+        let temp_dir = TempDir::new().unwrap();
+        let content =
+            "key,0,1,2\n#,Name,Description,BackgroundColor\nint32,str,str,Color\n1,\"Fire Element\",\"Element of fire\",16711680\n2,\"Water Element\",\"Element of water\",255";
+        let file_path = create_test_csv(&temp_dir, "ColorTest", content);
+
+        let mut builder = SchemaBuilder::new();
+        let result = builder.build_schema_from_file(&file_path);
+
+        assert!(result.is_ok());
+        let schema_name = result.unwrap();
+        assert_eq!(schema_name, "ColorTest");
+
+        let schema = &builder.get_all_schemas()["ColorTest"];
+        assert_eq!(schema.name, "ColorTest");
+        assert_eq!(schema.fields.len(), 4);
+
+        assert_eq!(schema.fields[0].name, "id");
+        assert_eq!(schema.fields[0].field_type, FieldType::Int32);
+
+        assert_eq!(schema.fields[1].name, "name");
+        assert_eq!(schema.fields[1].field_type, FieldType::String);
+
+        assert_eq!(schema.fields[2].name, "description");
+        assert_eq!(schema.fields[2].field_type, FieldType::String);
+
+        assert_eq!(schema.fields[3].name, "backgroundColor");
+        assert_eq!(schema.fields[3].field_type, FieldType::Color);
+    }
+
+    #[test]
+    fn test_mixed_special_types_with_color() {
+        let temp_dir = TempDir::new().unwrap();
+        let content =
+            "key,0,1,2,3,4\n#,Name,Icon,Ref,TextColor,Status\nint32,str,Image,Row,Color,Key\n1,\"Test Item\",\"021001\",0,16777215,\"active\"";
+        let file_path = create_test_csv(&temp_dir, "MixedSpecialTypes", content);
+
+        let mut builder = SchemaBuilder::new();
+        let result = builder.build_schema_from_file(&file_path);
+
+        assert!(result.is_ok());
+        let schema_name = result.unwrap();
+        assert_eq!(schema_name, "MixedSpecialTypes");
+
+        let schema = &builder.get_all_schemas()["MixedSpecialTypes"];
+        assert_eq!(schema.name, "MixedSpecialTypes");
+        assert_eq!(schema.fields.len(), 6);
+
+        assert_eq!(schema.fields[0].name, "id");
+        assert_eq!(schema.fields[0].field_type, FieldType::Int32);
+
+        assert_eq!(schema.fields[1].name, "name");
+        assert_eq!(schema.fields[1].field_type, FieldType::String);
+
+        assert_eq!(schema.fields[2].name, "icon");
+        assert_eq!(schema.fields[2].field_type, FieldType::Image);
+
+        assert_eq!(schema.fields[3].name, "ref");
+        assert_eq!(schema.fields[3].field_type, FieldType::Row);
+
+        assert_eq!(schema.fields[4].name, "textColor");
+        assert_eq!(schema.fields[4].field_type, FieldType::Color);
+
+        assert_eq!(schema.fields[5].name, "status");
+        assert_eq!(schema.fields[5].field_type, FieldType::Key);
+    }
 }

--- a/packages/noumenon-gleaner/src/schema/builder.rs
+++ b/packages/noumenon-gleaner/src/schema/builder.rs
@@ -211,6 +211,7 @@ impl SchemaBuilder {
                         "Image" => Ok(FieldType::Image),
                         "Row" => Ok(FieldType::Row),
                         "Key" => Ok(FieldType::Key),
+                        "Color" => Ok(FieldType::Color),
                         _ => Ok(FieldType::Custom(trimmed.to_string())), // For future special types
                     }
                 }

--- a/packages/noumenon-gleaner/src/schema/error.rs
+++ b/packages/noumenon-gleaner/src/schema/error.rs
@@ -2,8 +2,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum SchemaError {
-    #[error("File not found: {path}")]
-    FileNotFound { path: String },
+    #[error("File not found: {path} (referenced from: {source_file})")]
+    FileNotFound { path: String, source_file: String },
 
     #[error("CSV parsing error: {0}")]
     CsvError(#[from] csv::Error),

--- a/packages/noumenon-gleaner/src/schema/types.rs
+++ b/packages/noumenon-gleaner/src/schema/types.rs
@@ -47,7 +47,10 @@ mod tests {
     fn test_field_type_equality() {
         assert_eq!(FieldType::Image, FieldType::Image);
         assert_eq!(FieldType::Row, FieldType::Row);
+        assert_eq!(FieldType::Color, FieldType::Color);
         assert_ne!(FieldType::Image, FieldType::Row);
+        assert_ne!(FieldType::Color, FieldType::Image);
+        assert_ne!(FieldType::Color, FieldType::Row);
     }
 
     #[test]
@@ -59,6 +62,17 @@ mod tests {
 
         assert_eq!(field.name, "test_field");
         assert_eq!(field.field_type, FieldType::Image);
+    }
+
+    #[test]
+    fn test_color_field_creation() {
+        let color_field = Field {
+            name: "background_color".to_string(),
+            field_type: FieldType::Color,
+        };
+
+        assert_eq!(color_field.name, "background_color");
+        assert_eq!(color_field.field_type, FieldType::Color);
     }
 
     #[test]

--- a/packages/noumenon-gleaner/src/schema/types.rs
+++ b/packages/noumenon-gleaner/src/schema/types.rs
@@ -18,6 +18,7 @@ pub enum FieldType {
     Image, // UI image file path - preserved as-is without processing
     Row,   // Row type - preserved as-is without processing
     Key,   // Key type - string identifier preserved as-is without processing
+    Color, // Color type - converted to number (color code)
 
     // Custom types that reference other CSV files
     Custom(String),

--- a/packages/noumenon-gleaner/src/schema/typescript.rs
+++ b/packages/noumenon-gleaner/src/schema/typescript.rs
@@ -83,6 +83,9 @@ impl TypeScriptGenerator {
         types.push_str("/** Key identifier string */\n");
         types.push_str("export type KeyString = string;\n\n");
 
+        types.push_str("/** Color code identifier */\n");
+        types.push_str("export type ColorCode = number;\n\n");
+
         types
     }
 
@@ -100,6 +103,7 @@ impl TypeScriptGenerator {
             FieldType::Image => "ImagePath".to_string(), // Use special type
             FieldType::Row => "RowId".to_string(),     // Use special type
             FieldType::Key => "KeyString".to_string(), // Use special type
+            FieldType::Color => "ColorCode".to_string(), // Use special type
             FieldType::Custom(type_name) => type_name.clone(), // Reference to another interface
         }
     }

--- a/packages/noumenon-gleaner/src/schema/typescript.rs
+++ b/packages/noumenon-gleaner/src/schema/typescript.rs
@@ -179,6 +179,10 @@ mod tests {
             "KeyString"
         );
         assert_eq!(
+            generator.field_type_to_typescript(&FieldType::Color),
+            "ColorCode"
+        );
+        assert_eq!(
             generator.field_type_to_typescript(&FieldType::Custom("ItemCategory".to_string())),
             "ItemCategory"
         );
@@ -236,6 +240,52 @@ mod tests {
         assert!(typescript.contains("export type ImagePath = string;"));
         assert!(typescript.contains("export type RowId = number;"));
         assert!(typescript.contains("export type KeyString = string;"));
+        assert!(typescript.contains("export type ColorCode = number;"));
         assert!(typescript.starts_with("// Generated TypeScript interfaces"));
+    }
+
+    #[test]
+    fn test_color_type_typescript_generation() {
+        let generator = TypeScriptGenerator::new();
+        let mut schemas = HashMap::new();
+
+        // Create a schema with Color type field
+        let color_schema = Schema {
+            name: "ColoredItem".to_string(),
+            fields: vec![
+                Field {
+                    name: "id".to_string(),
+                    field_type: FieldType::Int32,
+                },
+                Field {
+                    name: "name".to_string(),
+                    field_type: FieldType::String,
+                },
+                Field {
+                    name: "backgroundColor".to_string(),
+                    field_type: FieldType::Color,
+                },
+                Field {
+                    name: "textColor".to_string(),
+                    field_type: FieldType::Color,
+                },
+            ],
+        };
+        schemas.insert("ColoredItem".to_string(), color_schema);
+
+        let typescript = generator.generate_typescript_interfaces(&schemas);
+
+        // Verify ColorCode type definition is generated
+        assert!(typescript.contains("export type ColorCode = number;"));
+        assert!(typescript.contains("/** Color code identifier */"));
+        
+        // Verify Color fields are properly typed
+        assert!(typescript.contains("backgroundColor: ColorCode;"));
+        assert!(typescript.contains("textColor: ColorCode;"));
+        
+        // Verify interface structure
+        assert!(typescript.contains("export interface ColoredItem"));
+        assert!(typescript.contains("id: number;"));
+        assert!(typescript.contains("name: string;"));
     }
 }

--- a/packages/noumenon-gleaner/src/schema/utils.rs
+++ b/packages/noumenon-gleaner/src/schema/utils.rs
@@ -119,6 +119,8 @@ mod tests {
         // Special types should return false (they have their own processing)
         assert!(!is_likely_custom_type("Image"));
         assert!(!is_likely_custom_type("Row"));
+        assert!(!is_likely_custom_type("Key"));
+        assert!(!is_likely_custom_type("Color"));
 
         // Custom types should return true
         assert!(is_likely_custom_type("ItemCategory"));
@@ -130,6 +132,8 @@ mod tests {
         // Special types should return true
         assert!(is_special_type("Image"));
         assert!(is_special_type("Row"));
+        assert!(is_special_type("Key"));
+        assert!(is_special_type("Color"));
 
         // Basic and custom types should return false
         assert!(!is_special_type("str"));
@@ -178,5 +182,42 @@ mod tests {
 
         // Test with current directory (should exist)
         assert!(Path::new(".").exists());
+    }
+
+    #[test]
+    fn test_color_type_not_treated_as_custom() {
+        // Create a mock StringRecord with Color type
+        let record = csv::StringRecord::from(vec!["str", "int32", "Color", "bool"]);
+        let base_dir = Path::new(".");
+
+        let missing_files = find_missing_files_in_types(&record, base_dir);
+
+        // Color should not be treated as a missing custom type
+        assert!(!missing_files.contains(&"Color".to_string()));
+        // Basic types should not be in the missing files
+        assert!(!missing_files.contains(&"str".to_string()));
+        assert!(!missing_files.contains(&"int32".to_string()));
+        assert!(!missing_files.contains(&"bool".to_string()));
+    }
+
+    #[test]
+    fn test_mixed_types_with_color() {
+        // Create a mock StringRecord mixing special types with custom types
+        let record = csv::StringRecord::from(vec!["str", "Color", "Image", "CustomType", "Row", "Key"]);
+        let base_dir = Path::new(".");
+
+        let missing_files = find_missing_files_in_types(&record, base_dir);
+
+        // Only CustomType should be detected as missing
+        assert!(missing_files.contains(&"CustomType".to_string()));
+        
+        // Special types should not be treated as missing
+        assert!(!missing_files.contains(&"Color".to_string()));
+        assert!(!missing_files.contains(&"Image".to_string()));
+        assert!(!missing_files.contains(&"Row".to_string()));
+        assert!(!missing_files.contains(&"Key".to_string()));
+        
+        // Basic type should not be treated as missing
+        assert!(!missing_files.contains(&"str".to_string()));
     }
 }


### PR DESCRIPTION
This PR adds support for the `Color` special type in the schema generation process, which is treated as a color code and converted to a number type in TypeScript output. The PR also improves error handling by including the source file reference in FileNotFound errors, making it easier to track down missing dependencies.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 색상 정보를 위한 새로운 특수 타입 "Color"가 추가되었습니다. 이제 스키마에서 색상 코드를 숫자 형태로 지정할 수 있습니다.
  * TypeScript 타입 정의에 "ColorCode" 타입이 추가되어 색상 필드를 명확하게 지원합니다.

* **문서화**
  * 스키마 생성 프로세스 문서가 "Color" 타입 설명 및 예시와 함께 업데이트되었습니다.

* **버그 수정**
  * 누락된 파일 오류 메시지에 참조한 원본 파일 경로가 추가되어 진단 정보가 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->