### PR TITLE
✨ (animation-practice): add StackedComponent to use scale and translate increments

### DIFF
--- a/playgrounds/animation-practice/app/(workspaces)/animation-on-the-web/stacked-component/page.tsx
+++ b/playgrounds/animation-practice/app/(workspaces)/animation-on-the-web/stacked-component/page.tsx
@@ -5,10 +5,13 @@ import { PageTitle } from '@/app/_components/PageTitle';
 import './styles.css';
 
 export default function Page() {
-  const { length } = useControls({
-    length: {
-      value: 3,
-      min: 1,
+  const { scaleIncrement, translateIncrement } = useControls({
+    scaleIncrement: {
+      value: defaultProps.scaleIncrement,
+      step: 0.01,
+    },
+    translateIncrement: {
+      value: defaultProps.translateIncrement,
       step: 1,
     },
   });
@@ -16,21 +19,45 @@ export default function Page() {
   return (
     <>
       <PageTitle title="Stacked Component" />
-      <StackedComponent length={length} />
+      <StackedComponent
+        scaleIncrement={scaleIncrement}
+        translateIncrement={translateIncrement}
+      />
     </>
   );
 }
 
 interface StackedComponentProps {
-  length?: number;
+  scaleIncrement: number;
+  translateIncrement: string;
 }
 
-export function StackedComponent({ length = 3 }: StackedComponentProps) {
+const defaultProps: StackedComponentProps = {
+  scaleIncrement: 0.05,
+  translateIncrement: '-13%',
+};
+
+const LENGTH = 3;
+
+export function StackedComponent({
+  scaleIncrement = defaultProps.scaleIncrement,
+  translateIncrement = defaultProps.translateIncrement,
+}: StackedComponentProps) {
   return (
     <div className="wrapper">
-      {Array.from({ length }).map((_, i) => (
-        // biome-ignore lint/suspicious/noArrayIndexKey: not important in this case
-        <div className="card" key={i} />
+      {Array.from({ length: LENGTH }).map((_, i) => (
+        <div
+          className="card"
+          // biome-ignore lint/suspicious/noArrayIndexKey: not important in this case
+          key={i}
+          style={
+            {
+              '--index': LENGTH - 1 - i,
+              '--scale-increment': `${scaleIncrement}`,
+              '--translate-increment': `${translateIncrement}`,
+            } as React.CSSProperties
+          }
+        />
       ))}
     </div>
   );

--- a/playgrounds/animation-practice/app/(workspaces)/animation-on-the-web/stacked-component/page.tsx
+++ b/playgrounds/animation-practice/app/(workspaces)/animation-on-the-web/stacked-component/page.tsx
@@ -44,7 +44,7 @@ export function StackedComponent({
   translateIncrement = defaultProps.translateIncrement,
 }: StackedComponentProps) {
   return (
-    <div className="wrapper">
+    <div className="stacked-component-wrapper">
       {Array.from({ length: LENGTH }).map((_, i) => (
         <div
           className="card"

--- a/playgrounds/animation-practice/app/(workspaces)/animation-on-the-web/stacked-component/styles.css
+++ b/playgrounds/animation-practice/app/(workspaces)/animation-on-the-web/stacked-component/styles.css
@@ -10,4 +10,7 @@
   background: white;
   border-radius: 8px;
   grid-area: 1 / 1;
+
+  transform: scale(calc(1 - var(--index) * var(--scale-increment)))
+    translateY(calc(var(--index) * var(--translate-increment)));
 }

--- a/playgrounds/animation-practice/app/(workspaces)/animation-on-the-web/stacked-component/styles.css
+++ b/playgrounds/animation-practice/app/(workspaces)/animation-on-the-web/stacked-component/styles.css
@@ -1,8 +1,8 @@
-.wrapper {
+.stacked-component-wrapper {
   display: grid;
 }
 
-.card {
+.stacked-component-wrapper .card {
   width: 356px;
   height: 74px;
   box-shadow: 0 4px 12px #0000001a;


### PR DESCRIPTION
### TL;DR

Added dynamic stacking effect to the StackedComponent with configurable scale and translation parameters.

### What changed?

- Replaced the `length` control with `scaleIncrement` and `translateIncrement` parameters
- Created a `defaultProps` object to store default values
- Added CSS transform properties to create a stacking effect for cards
- Set a constant `LENGTH` instead of using a variable length
- Added inline styles to each card with CSS variables for scaling and translation
- Implemented proper z-ordering by reversing the index calculation

### How to test?

1. Navigate to the animation-on-the-web/stacked-component page
2. Use the controls to adjust the `scaleIncrement` and `translateIncrement` values
3. Observe how the cards stack with different scaling and translation effects
4. Verify that the cards properly stack with the top card at full size and subsequent cards scaled down and translated

### Why make this change?

This change enhances the StackedComponent by adding a visually appealing stacking effect where each card is slightly smaller and offset from the one above it. By making the scale and translation parameters configurable, it allows for easy experimentation with different stacking styles without modifying the core component code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 카드 스택의 확대 비율(scale)과 세로 이동(translate)을 별도 UI 컨트롤로 실시간 조정할 수 있습니다.
* 개선
  * CSS 변수 기반 변환을 적용해 카드 스택 애니메이션이 더 매끄럽고 일관되게 동작합니다.
  * 스택의 카드 수를 3장으로 고정해 레이아웃 예측 가능성이 높아졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->